### PR TITLE
count comments on dto mapping

### DIFF
--- a/src/main/java/com/code4ro/legalconsultation/converters/DocumentConsolidatedMapper.java
+++ b/src/main/java/com/code4ro/legalconsultation/converters/DocumentConsolidatedMapper.java
@@ -2,21 +2,12 @@ package com.code4ro.legalconsultation.converters;
 
 import com.code4ro.legalconsultation.model.dto.DocumentConsolidatedDto;
 import com.code4ro.legalconsultation.model.persistence.DocumentConsolidated;
-import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
-import org.mapstruct.MappingTarget;
 
-import java.math.BigInteger;
-
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring",
+        uses = {DocumentMetadataMapper.class, DocumentNodeMapper.class})
 public interface DocumentConsolidatedMapper {
 
-    DocumentConsolidatedDto map(DocumentConsolidated documentConsolidated, BigInteger numberOfComments);
+    DocumentConsolidatedDto map(DocumentConsolidated documentConsolidated);
 
-    @AfterMapping
-    default void setNumberOfComments(@MappingTarget DocumentConsolidatedDto dto, BigInteger numberOfComments) {
-        if (dto.getDocumentNode() != null) {
-            dto.getDocumentNode().setNumberOfComments(numberOfComments);
-        }
-    }
 }

--- a/src/main/java/com/code4ro/legalconsultation/converters/DocumentNodeMapper.java
+++ b/src/main/java/com/code4ro/legalconsultation/converters/DocumentNodeMapper.java
@@ -5,7 +5,7 @@ import com.code4ro.legalconsultation.model.dto.documentnode.DocumentNodeDto;
 import com.code4ro.legalconsultation.model.persistence.DocumentNode;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {NumberOfCommentsMapper.class})
 public interface DocumentNodeMapper {
 
     DocumentNodeDto map(DocumentNode documentNode);

--- a/src/main/java/com/code4ro/legalconsultation/converters/NumberOfCommentsMapper.java
+++ b/src/main/java/com/code4ro/legalconsultation/converters/NumberOfCommentsMapper.java
@@ -1,0 +1,23 @@
+package com.code4ro.legalconsultation.converters;
+
+import com.code4ro.legalconsultation.model.dto.documentnode.DocumentNodeDto;
+import com.code4ro.legalconsultation.model.persistence.DocumentNode;
+import com.code4ro.legalconsultation.repository.CommentRepository;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Mapper(componentModel = "spring")
+public abstract class NumberOfCommentsMapper {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @AfterMapping
+    public void computeNumberOfComments(@MappingTarget DocumentNodeDto dto, DocumentNode model) {
+        dto.setNumberOfComments(commentRepository.countByDocumentNodeId(model.getId()));
+    }
+}
+
+

--- a/src/main/java/com/code4ro/legalconsultation/service/impl/DocumentServiceImpl.java
+++ b/src/main/java/com/code4ro/legalconsultation/service/impl/DocumentServiceImpl.java
@@ -72,10 +72,7 @@ public class DocumentServiceImpl implements DocumentService {
     @Override
     public DocumentConsolidatedDto fetchConsolidatedByMetadataId(final UUID id) {
         final DocumentConsolidated document = documentConsolidatedService.getByDocumentMetadataId(id);
-        UUID documentNodeId = document.getDocumentNode().getId();
-        BigInteger noOfcComments = commentService.count(documentNodeId);
-
-        return documentConsolidatedMapper.map(document, noOfcComments);
+        return documentConsolidatedMapper.map(document);
     }
 
     @Transactional

--- a/src/test/java/com/code4ro/legalconsultation/service/DocumentServiceTest.java
+++ b/src/test/java/com/code4ro/legalconsultation/service/DocumentServiceTest.java
@@ -73,8 +73,7 @@ public class DocumentServiceTest {
         document.setDocumentNode(documentNode);
 
         when(documentConsolidatedService.getByDocumentMetadataId(any(UUID.class))).thenReturn(document);
-        when(commentService.count(documentNode.getId())).thenReturn(BigInteger.ONE);
-        when(documentConsolidatedMapper.map(any(), any())).thenReturn(new DocumentConsolidatedDto());
+        when(documentConsolidatedMapper.map(any())).thenReturn(new DocumentConsolidatedDto());
 
         documentService.fetchConsolidatedByMetadataId(uuid);
 


### PR DESCRIPTION
fixes #137 

In the initial implementation, the DocumentNodeDto.numberOfComments is computed in the service clas and related container mapper (DocumentConsolidatedMapper).

Actually, the responsibility should lie with DocumentNodeMapper.

The current implementation delegates to a custom mapper specialized for this purpose.
This is because it relies on accessing the CommentsRepo for the mapping implementation.

ALTERNATIVE
A simpler alternative would be to modify the model such that  we add 
DocumentNode#comments.

This would remove the need to access the CommentsRepo (as the access  would be transparently computed by Hibernate).




