### PR TITLE
Return unique identifier for S3 load file

### DIFF
--- a/src/main/java/com/code4ro/legalconsultation/service/impl/AmazonS3StorageService.java
+++ b/src/main/java/com/code4ro/legalconsultation/service/impl/AmazonS3StorageService.java
@@ -73,7 +73,7 @@ public class AmazonS3StorageService implements StorageApi {
             log.error("Storing of document with name: {} failed.", uniqueDocumentName, e);
             throw new LegalValidationException("storage.upload.failed", HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return amazonS3.getUrl(documentBucket, uniqueDocumentName).toString();
+        return uniqueDocumentName;
     }
 
     @Override

--- a/src/test/java/com/code4ro/legalconsultation/service/AmazonS3StorageServiceTest.java
+++ b/src/test/java/com/code4ro/legalconsultation/service/AmazonS3StorageServiceTest.java
@@ -51,12 +51,10 @@ public class AmazonS3StorageServiceTest {
     public void storeFile() throws Exception {
         final MultipartFile randomFile = new MockMultipartFile("file", "file", "text/plain",
                 "text".getBytes());
-        when(client.getUrl(eq(documentBucket), anyString())).thenReturn(new URL("http://url"));
 
         storageService.storeFile(randomFile);
 
         verify(client).putObject(putObjectRequestArgumentCaptor.capture());
-        verify(client).getUrl(eq(documentBucket), anyString());
 
         final PutObjectRequest putObjectRequest = putObjectRequestArgumentCaptor.getValue();
         assertThat(putObjectRequest.getBucketName()).isEqualTo(documentBucket);


### PR DESCRIPTION
For S3 upload, we need to return the identifier for the S3 file, not the complete URL. The identifier is used for reading the file using the AWS API.