### PR TITLE
Fix `DocumentNodeParser::getCurentLine()`

### DIFF
--- a/src/main/java/com/code4ro/legalconsultation/service/impl/pdf/parser/DocumentNodeParser.java
+++ b/src/main/java/com/code4ro/legalconsultation/service/impl/pdf/parser/DocumentNodeParser.java
@@ -102,7 +102,7 @@ public abstract class DocumentNodeParser {
     }
 
     private String getCurrentLine() {
-        return lines[metadata.getCurrentLineIndex()].trim() + " ";
+        return lines[metadata.getCurrentLineIndex()].trim();
     }
 
     private void skipTitleLines(final String title) {


### PR DESCRIPTION
Remove the added whitespace at the end of the line.

Fixes #152 