### PR TITLE
Get all pending comments based on the user rights

### DIFF
--- a/src/main/java/com/code4ro/legalconsultation/comment/controller/CommentController.java
+++ b/src/main/java/com/code4ro/legalconsultation/comment/controller/CommentController.java
@@ -13,7 +13,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
@@ -21,87 +24,39 @@ import static com.code4ro.legalconsultation.comment.model.persistence.CommentSta
 import static com.code4ro.legalconsultation.comment.model.persistence.CommentStatus.REJECTED;
 
 @RestController
-@RequestMapping("/api/documentnodes/{nodeId}/comments")
+@RequestMapping("/api/comments")
 @RequiredArgsConstructor
 public class CommentController {
-
     private final CommentService commentService;
     private final CommentMapper commentMapper;
 
-    @ApiOperation(value = "Create a new comment in the platform",
-            response = CommentDto.class,
-            produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping
-    public ResponseEntity<CommentDetailDto> create(@ApiParam(value = "The id of the node") @PathVariable final UUID nodeId,
-                                                   @ApiParam("The DTO object containing a new comment") @RequestBody final CommentDto commentDto) {
-        CommentDetailDto comment = commentService.create(nodeId, commentDto);
-        return ResponseEntity.ok(comment);
-    }
-
-    @ApiOperation(value = "Update a comment in the platform",
-            response = CommentDto.class,
-            produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE)
-    @PutMapping("/{id}")
-    public ResponseEntity<CommentDetailDto> update(@ApiParam(value = "The id of the node") @PathVariable final UUID nodeId,
-                                                   @ApiParam(value = "The id of the comment") @PathVariable final UUID id,
-                                                   @ApiParam("The DTO object to update") @RequestBody final CommentDto commentDto) {
-        return ResponseEntity.ok(commentService.update(nodeId, id, commentDto));
-    }
-
-    @ApiOperation(value = "Delete a comment",
-            produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE)
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@ApiParam(value = "The id of the comment") @PathVariable final UUID id) {
-        commentService.delete(id);
-        return ResponseEntity.ok().build();
-    }
-
-    @ApiOperation(value = "Get all comments of a node",
+    @ApiOperation(value = "Get all pending comments for approval",
             response = PageDto.class,
             produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
-    @GetMapping
-    public ResponseEntity<PageDto<CommentDetailDto>> findAll(@ApiParam(value = "The id of the node") @PathVariable final UUID nodeId,
-                                                             @ApiParam("Page object information being requested") final Pageable pageable) {
-        Page<Comment> comments = commentService.findAll(nodeId, pageable);
-        Page<CommentDetailDto> commentsDto = comments.map(commentMapper::mapToCommentDetailDto);
+    @GetMapping("/pending")
+    public ResponseEntity<PageDto<CommentDetailDto>> findAllPending(@ApiParam("Page object information being requested") final Pageable pageable) {
+        final Page<Comment> comments = commentService.findAllPending(pageable);
+        final Page<CommentDetailDto> commentsDto = comments.map(commentMapper::mapToCommentDetailDto);
 
         return ResponseEntity.ok(new PageDto<>(commentsDto));
     }
 
+    @ApiOperation(value = "Approve pending comment",
+            response = PageDto.class,
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.APPLICATION_JSON_VALUE)
     @GetMapping("/{commentId}/approve")
     public ResponseEntity<CommentDto> approve(@PathVariable UUID commentId) {
         return ResponseEntity.ok(commentService.setStatus(commentId, APPROVED));
     }
 
-    @GetMapping("/{commentId}/reject")
-    public ResponseEntity<CommentDto> reject(@PathVariable UUID commentId) {
-        return ResponseEntity.ok(commentService.setStatus(commentId, REJECTED));
-    }
-
-    @ApiOperation(value = "Get all replies of a comment",
+    @ApiOperation(value = "Reject pending comment",
             response = PageDto.class,
             produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
-    @GetMapping("/{commentId}/replies")
-    public ResponseEntity<PageDto<CommentDetailDto>> findAllReplies(@ApiParam(value = "The id of the comment") @PathVariable final UUID commentId,
-                                                                    @ApiParam("Page object information being requested") final Pageable pageable) {
-        Page<Comment> replies = commentService.findAllReplies(commentId, pageable);
-        Page<CommentDetailDto> repliesDto = replies.map(commentMapper::mapToCommentDetailDto);
-
-        return ResponseEntity.ok(new PageDto<>(repliesDto));
-    }
-
-    @ApiOperation(value = "Create a new reply in the platform",
-            response = CommentDto.class,
-            produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping("/{commentId}/replies")
-    public ResponseEntity<CommentDetailDto> createReply(@ApiParam(value = "The id of the comment") @PathVariable final UUID commentId,
-                                                        @ApiParam("The DTO object containing a new reply") @RequestBody CommentDto commentDto) {
-        return ResponseEntity.ok(commentService.createReply(commentId, commentDto));
+    @GetMapping("/{commentId}/reject")
+    public ResponseEntity<CommentDto> reject(@PathVariable UUID commentId) {
+        return ResponseEntity.ok(commentService.setStatus(commentId, REJECTED));
     }
 }

--- a/src/main/java/com/code4ro/legalconsultation/comment/controller/DocumentCommentsController.java
+++ b/src/main/java/com/code4ro/legalconsultation/comment/controller/DocumentCommentsController.java
@@ -1,0 +1,97 @@
+package com.code4ro.legalconsultation.comment.controller;
+
+import com.code4ro.legalconsultation.comment.mapper.CommentMapper;
+import com.code4ro.legalconsultation.comment.model.dto.CommentDetailDto;
+import com.code4ro.legalconsultation.comment.model.dto.CommentDto;
+import com.code4ro.legalconsultation.comment.model.persistence.Comment;
+import com.code4ro.legalconsultation.comment.service.CommentService;
+import com.code4ro.legalconsultation.core.model.dto.PageDto;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+import static com.code4ro.legalconsultation.comment.model.persistence.CommentStatus.APPROVED;
+import static com.code4ro.legalconsultation.comment.model.persistence.CommentStatus.REJECTED;
+
+@RestController
+@RequestMapping("/api/documentnodes/{nodeId}/comments")
+@RequiredArgsConstructor
+public class DocumentCommentsController {
+
+    private final CommentService commentService;
+    private final CommentMapper commentMapper;
+
+    @ApiOperation(value = "Create a new comment in the platform",
+            response = CommentDto.class,
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping
+    public ResponseEntity<CommentDetailDto> create(@ApiParam(value = "The id of the node") @PathVariable final UUID nodeId,
+                                                   @ApiParam("The DTO object containing a new comment") @RequestBody final CommentDto commentDto) {
+        CommentDetailDto comment = commentService.create(nodeId, commentDto);
+        return ResponseEntity.ok(comment);
+    }
+
+    @ApiOperation(value = "Update a comment in the platform",
+            response = CommentDto.class,
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping("/{id}")
+    public ResponseEntity<CommentDetailDto> update(@ApiParam(value = "The id of the node") @PathVariable final UUID nodeId,
+                                                   @ApiParam(value = "The id of the comment") @PathVariable final UUID id,
+                                                   @ApiParam("The DTO object to update") @RequestBody final CommentDto commentDto) {
+        return ResponseEntity.ok(commentService.update(nodeId, id, commentDto));
+    }
+
+    @ApiOperation(value = "Delete a comment",
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@ApiParam(value = "The id of the comment") @PathVariable final UUID id) {
+        commentService.delete(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @ApiOperation(value = "Get all comments of a node",
+            response = PageDto.class,
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping
+    public ResponseEntity<PageDto<CommentDetailDto>> findAll(@ApiParam(value = "The id of the node") @PathVariable final UUID nodeId,
+                                                             @ApiParam("Page object information being requested") final Pageable pageable) {
+        Page<Comment> comments = commentService.findAll(nodeId, pageable);
+        Page<CommentDetailDto> commentsDto = comments.map(commentMapper::mapToCommentDetailDto);
+
+        return ResponseEntity.ok(new PageDto<>(commentsDto));
+    }
+
+    @ApiOperation(value = "Get all replies of a comment",
+            response = PageDto.class,
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping("/{commentId}/replies")
+    public ResponseEntity<PageDto<CommentDetailDto>> findAllReplies(@ApiParam(value = "The id of the comment") @PathVariable final UUID commentId,
+                                                                    @ApiParam("Page object information being requested") final Pageable pageable) {
+        Page<Comment> replies = commentService.findAllReplies(commentId, pageable);
+        Page<CommentDetailDto> repliesDto = replies.map(commentMapper::mapToCommentDetailDto);
+
+        return ResponseEntity.ok(new PageDto<>(repliesDto));
+    }
+
+    @ApiOperation(value = "Create a new reply in the platform",
+            response = CommentDto.class,
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping("/{commentId}/replies")
+    public ResponseEntity<CommentDetailDto> createReply(@ApiParam(value = "The id of the comment") @PathVariable final UUID commentId,
+                                                        @ApiParam("The DTO object containing a new reply") @RequestBody CommentDto commentDto) {
+        return ResponseEntity.ok(commentService.createReply(commentId, commentDto));
+    }
+}

--- a/src/main/java/com/code4ro/legalconsultation/comment/model/persistence/CommentStatus.java
+++ b/src/main/java/com/code4ro/legalconsultation/comment/model/persistence/CommentStatus.java
@@ -1,6 +1,7 @@
 package com.code4ro.legalconsultation.comment.model.persistence;
 
 public enum CommentStatus {
+    PENDING,
     APPROVED,
     REJECTED
 }

--- a/src/main/java/com/code4ro/legalconsultation/comment/repository/CommentRepository.java
+++ b/src/main/java/com/code4ro/legalconsultation/comment/repository/CommentRepository.java
@@ -1,20 +1,29 @@
 package com.code4ro.legalconsultation.comment.repository;
 
 import com.code4ro.legalconsultation.comment.model.persistence.Comment;
+import com.code4ro.legalconsultation.comment.model.persistence.CommentStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigInteger;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
-    Page<Comment> findByDocumentNodeIdAndParentIsNull(final UUID nodeId,
-                                       final Pageable pageable);
+    Page<Comment> findByDocumentNodeIdAndParentIsNullAndStatus(final UUID nodeId,
+                                                               final CommentStatus status,
+                                                               final Pageable pageable);
 
     Page<Comment> findByParentId(UUID parentId, Pageable pageable);
 
-    BigInteger countByDocumentNodeId(final UUID nodeId);
+    BigInteger countByDocumentNodeIdAndStatus(final UUID nodeId, final CommentStatus status);
+
+    Page<Comment> findAllByStatus(CommentStatus status, Pageable pageable);
+
+    Page<Comment> findAllByDocumentNode_IdInAndStatus(List<UUID> documentNodeIds,
+                                                      CommentStatus status,
+                                                      Pageable pageable);
 }

--- a/src/main/java/com/code4ro/legalconsultation/comment/service/CommentService.java
+++ b/src/main/java/com/code4ro/legalconsultation/comment/service/CommentService.java
@@ -28,4 +28,6 @@ public interface CommentService {
     CommentDto setStatus(UUID commentId, CommentStatus approved);
 
     Comment findById(UUID id);
+
+    Page<Comment> findAllPending(Pageable pageable);
 }

--- a/src/main/java/com/code4ro/legalconsultation/document/consolidated/repository/DocumentConsolidatedRepository.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/consolidated/repository/DocumentConsolidatedRepository.java
@@ -1,9 +1,11 @@
 package com.code4ro.legalconsultation.document.consolidated.repository;
 
 import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
+import com.code4ro.legalconsultation.user.model.persistence.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +14,6 @@ public interface DocumentConsolidatedRepository extends JpaRepository<DocumentCo
     Optional<DocumentConsolidated> findByDocumentMetadataId(UUID id);
 
     Optional<DocumentConsolidated> findByDocumentNodeId(UUID id);
+
+    List<DocumentConsolidated> findAllByAssignedUsersContaining(User user);
 }

--- a/src/main/java/com/code4ro/legalconsultation/document/consolidated/service/DocumentConsolidatedService.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/consolidated/service/DocumentConsolidatedService.java
@@ -1,10 +1,11 @@
 package com.code4ro.legalconsultation.document.consolidated.service;
 
 import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
+import com.code4ro.legalconsultation.document.consolidated.repository.DocumentConsolidatedRepository;
 import com.code4ro.legalconsultation.document.metadata.model.persistence.DocumentMetadata;
 import com.code4ro.legalconsultation.document.node.model.persistence.DocumentNode;
-import com.code4ro.legalconsultation.document.consolidated.repository.DocumentConsolidatedRepository;
 import com.code4ro.legalconsultation.document.node.service.DocumentNodeService;
+import com.code4ro.legalconsultation.user.model.persistence.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -73,5 +74,9 @@ public class DocumentConsolidatedService {
         consolidated.setDocumentMetadata(metadata);
         consolidated.setDocumentNode(documentNode);
         return documentConsolidatedRepository.save(consolidated);
+    }
+
+    public List<DocumentConsolidated> getAllAssignedDocuments(final User user) {
+        return documentConsolidatedRepository.findAllByAssignedUsersContaining(user);
     }
 }

--- a/src/main/java/com/code4ro/legalconsultation/document/core/service/DocumentService.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/core/service/DocumentService.java
@@ -9,6 +9,7 @@ import com.code4ro.legalconsultation.document.metadata.model.dto.DocumentViewDto
 import com.code4ro.legalconsultation.document.metadata.model.persistence.DocumentMetadata;
 import com.code4ro.legalconsultation.pdf.model.dto.PdfHandleDto;
 import com.code4ro.legalconsultation.user.model.dto.UserDto;
+import com.code4ro.legalconsultation.user.model.persistence.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -54,6 +55,8 @@ public interface DocumentService {
     PdfHandleDto addPdf(final UUID id, final String state, final MultipartFile file);
 
     byte[] export(final UUID id, final DocumentExportFormat type);
+
+    List<UUID> getAllAssignedDocumentsNodeIds(User user);
 
     void addConsultationData(final UUID id, final DocumentConsultationDataDto consultationDataDto);
 

--- a/src/main/java/com/code4ro/legalconsultation/document/core/service/impl/DocumentServiceImpl.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/core/service/impl/DocumentServiceImpl.java
@@ -5,6 +5,7 @@ import com.code4ro.legalconsultation.document.consolidated.mapper.DocumentConsol
 import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentConsolidatedDto;
 import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentConsultationDataDto;
 import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
+import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
 import com.code4ro.legalconsultation.document.consolidated.service.DocumentConsolidatedService;
 import com.code4ro.legalconsultation.document.core.service.DocumentService;
 import com.code4ro.legalconsultation.document.export.model.DocumentExportFormat;
@@ -34,10 +35,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class DocumentServiceImpl implements DocumentService {
@@ -181,6 +185,17 @@ public class DocumentServiceImpl implements DocumentService {
         final DocumentConsolidated documentConsolidated = documentConsolidatedService.getEntity(id);
         return exporter.export(documentConsolidated);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<UUID> getAllAssignedDocumentsNodeIds(final User user) {
+        final List<DocumentConsolidated> documents = documentConsolidatedService.getAllAssignedDocuments(user);
+        return documents.stream()
+                .flatMap(document -> document.getDocumentNode().flattened())
+                .map(DocumentNode::getId)
+                .collect(Collectors.toList());
+    }
+
 
     @Override
     public void addConsultationData(final UUID id, final DocumentConsultationDataDto consultationDataDto) {

--- a/src/main/java/com/code4ro/legalconsultation/document/node/mapper/NumberOfCommentsMapper.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/node/mapper/NumberOfCommentsMapper.java
@@ -1,8 +1,9 @@
 package com.code4ro.legalconsultation.document.node.mapper;
 
+import com.code4ro.legalconsultation.comment.model.persistence.CommentStatus;
+import com.code4ro.legalconsultation.comment.repository.CommentRepository;
 import com.code4ro.legalconsultation.document.node.model.dto.DocumentNodeDto;
 import com.code4ro.legalconsultation.document.node.model.persistence.DocumentNode;
-import com.code4ro.legalconsultation.comment.repository.CommentRepository;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
@@ -16,7 +17,7 @@ public abstract class NumberOfCommentsMapper {
 
     @AfterMapping
     public void computeNumberOfComments(@MappingTarget DocumentNodeDto dto, DocumentNode model) {
-        dto.setNumberOfComments(commentRepository.countByDocumentNodeId(model.getId()));
+        dto.setNumberOfComments(commentRepository.countByDocumentNodeIdAndStatus(model.getId(), CommentStatus.APPROVED));
     }
 }
 

--- a/src/main/java/com/code4ro/legalconsultation/document/node/model/persistence/DocumentNode.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/node/model/persistence/DocumentNode.java
@@ -7,6 +7,7 @@ import lombok.ToString;
 
 import javax.persistence.*;
 import java.util.List;
+import java.util.stream.Stream;
 
 @Entity
 @Table(name = "document_nodes")
@@ -14,7 +15,7 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class DocumentNode extends BaseEntity {
 
-    @ManyToOne(cascade = { CascadeType.DETACH, CascadeType.REFRESH, CascadeType.MERGE, CascadeType.PERSIST})
+    @ManyToOne(cascade = {CascadeType.DETACH, CascadeType.REFRESH, CascadeType.MERGE, CascadeType.PERSIST})
     @JoinColumn(name = "parent")
     @ToString.Exclude
     private DocumentNode parent;
@@ -38,4 +39,11 @@ public class DocumentNode extends BaseEntity {
 
     @Column(name = "node_index")
     private Integer index;
+
+    public Stream<DocumentNode> flattened() {
+        return Stream.concat(
+                Stream.of(this),
+                children != null ? children.stream().flatMap(DocumentNode::flattened) : Stream.empty());
+    }
+
 }

--- a/src/test/java/com/code4ro/legalconsultation/comment/controller/CommentsControllerTest.java
+++ b/src/test/java/com/code4ro/legalconsultation/comment/controller/CommentsControllerTest.java
@@ -1,0 +1,157 @@
+package com.code4ro.legalconsultation.comment.controller;
+
+import com.code4ro.legalconsultation.authentication.model.dto.SignUpRequest;
+import com.code4ro.legalconsultation.authentication.model.persistence.ApplicationUser;
+import com.code4ro.legalconsultation.comment.factory.CommentFactory;
+import com.code4ro.legalconsultation.comment.model.dto.CommentDetailDto;
+import com.code4ro.legalconsultation.comment.model.persistence.CommentStatus;
+import com.code4ro.legalconsultation.comment.service.CommentService;
+import com.code4ro.legalconsultation.core.controller.AbstractControllerIntegrationTest;
+import com.code4ro.legalconsultation.core.factory.RandomObjectFiller;
+import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
+import com.code4ro.legalconsultation.document.core.service.DocumentService;
+import com.code4ro.legalconsultation.document.node.factory.DocumentFactory;
+import com.code4ro.legalconsultation.invitation.model.persistence.Invitation;
+import com.code4ro.legalconsultation.invitation.model.persistence.InvitationStatus;
+import com.code4ro.legalconsultation.user.factory.UserFactory;
+import com.code4ro.legalconsultation.user.model.persistence.User;
+import com.code4ro.legalconsultation.user.model.persistence.UserRole;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@EnableJpaAuditing
+public class CommentsControllerTest extends AbstractControllerIntegrationTest {
+    @Autowired
+    private CommentService commentService;
+    @Autowired
+    private DocumentFactory documentFactory;
+    @Autowired
+    private CommentFactory commentFactory;
+    @Autowired
+    private UserFactory userFactory;
+    @Autowired
+    private DocumentService documentService;
+
+    @Test
+    @WithMockUser
+    @Transactional
+    public void findAllPendingWithAdminUser() throws Exception {
+        persistCurrentUser(UserRole.ADMIN);
+
+        final DocumentConsolidated document1 = documentFactory.create();
+        final DocumentConsolidated document2 = documentFactory.create();
+        final DocumentConsolidated document3 = documentFactory.create();
+
+        commentService.create(document1.getDocumentNode().getId(), commentFactory.create());
+        commentService.create(document2.getDocumentNode().getChildren().get(0).getId(), commentFactory.create());
+        final CommentDetailDto comment3 = commentService
+                .create(document3.getDocumentNode().getChildren().get(0).getId(), commentFactory.create());
+        commentService.create(document3.getDocumentNode().getId(), commentFactory.create());
+        commentService.setStatus(comment3.getId(), CommentStatus.APPROVED);
+
+        mvc.perform(get(endpoint("/api/comments/pending?page=0&size=10"))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content.size()").value(3))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.pageable.pageSize").value(10))
+                .andExpect(jsonPath("$.pageable.pageNumber").value(0))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @Transactional
+    public void findAllPendingWithOwnerUser() throws Exception {
+        persistCurrentUser(UserRole.OWNER);
+
+        final DocumentConsolidated document1 = documentFactory.create();
+        final DocumentConsolidated document2 = documentFactory.create();
+        final DocumentConsolidated document3 = documentFactory.create();
+
+        commentService.create(document1.getDocumentNode().getId(), commentFactory.create());
+        commentService.create(document2.getDocumentNode().getChildren().get(0).getId(), commentFactory.create());
+        final CommentDetailDto comment3 = commentService
+                .create(document3.getDocumentNode().getChildren().get(0).getId(), commentFactory.create());
+        commentService.create(document3.getDocumentNode().getId(), commentFactory.create());
+        commentService.setStatus(comment3.getId(), CommentStatus.APPROVED);
+
+        mvc.perform(get(endpoint("/api/comments/pending?page=0&size=10"))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content.size()").value(3))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.pageable.pageSize").value(10))
+                .andExpect(jsonPath("$.pageable.pageNumber").value(0))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @Transactional
+    public void findAllPendingWithRegularUser() throws Exception {
+        final ApplicationUser applicationUser = persistCurrentUser(UserRole.CONTRIBUTOR);
+
+        final DocumentConsolidated document1 = documentFactory.create();
+        final DocumentConsolidated document2 = documentFactory.create();
+        final DocumentConsolidated document3 = documentFactory.create();
+
+        documentService.assignUsers(document1.getDocumentMetadata().getId(), Set.of(applicationUser.getUser().getId()));
+        documentService.assignUsers(document3.getDocumentMetadata().getId(), Set.of(applicationUser.getUser().getId()));
+
+        final CommentDetailDto comment1 = commentService.create(document1.getDocumentNode().getId(), commentFactory.create());
+        final CommentDetailDto comment2 = commentService.create(document2.getDocumentNode().getChildren().get(0).getId(), commentFactory.create());
+        final CommentDetailDto comment3 = commentService
+                .create(document3.getDocumentNode().getChildren().get(0).getId(), commentFactory.create());
+        final CommentDetailDto comment4 = commentService.create(document3.getDocumentNode().getId(), commentFactory.create());
+        commentService.setStatus(comment3.getId(), CommentStatus.APPROVED);
+
+        final MvcResult mvcResult = mvc.perform(get(endpoint("/api/comments/pending?page=0&size=10"))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content.size()").value(2))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andExpect(jsonPath("$.pageable.pageSize").value(10))
+                .andExpect(jsonPath("$.pageable.pageNumber").value(0))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        final String contentAsString = mvcResult.getResponse().getContentAsString();
+
+        assertThat(contentAsString).contains(comment1.getId().toString());
+        assertThat(contentAsString).contains(comment4.getId().toString());
+        assertThat(contentAsString).doesNotContain(comment3.getId().toString());
+        assertThat(contentAsString).doesNotContain(comment2.getId().toString());
+    }
+
+    private ApplicationUser persistCurrentUser(final UserRole role) {
+        final ApplicationUser applicationUser = userFactory.createApplicationUserWithRole(role);
+        final User user = userRepository.save(applicationUser.getUser());
+        final Invitation invitation = RandomObjectFiller.createAndFill(Invitation.class);
+        invitation.setUser(user);
+        invitation.setStatus(InvitationStatus.PENDING);
+        invitationRepository.save(invitation);
+
+        final SignUpRequest signUpRequest = RandomObjectFiller.createAndFill(SignUpRequest.class);
+        signUpRequest.setUsername("user");
+        signUpRequest.setPassword("password");
+        signUpRequest.setInvitationCode(invitation.getCode());
+        signUpRequest.setEmail(user.getEmail());
+        applicationUserService.save(signUpRequest);
+
+        applicationUser.setUser(user);
+        return applicationUser;
+    }
+}

--- a/src/test/java/com/code4ro/legalconsultation/comment/controller/DocumentCommentsControllerIntegrationTest.java
+++ b/src/test/java/com/code4ro/legalconsultation/comment/controller/DocumentCommentsControllerIntegrationTest.java
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @EnableJpaAuditing
-public class CommentControllerIntegrationTest extends AbstractControllerIntegrationTest {
+public class DocumentCommentsControllerIntegrationTest extends AbstractControllerIntegrationTest {
 
     @Autowired
     private CommentRepository commentRepository;
@@ -42,8 +42,6 @@ public class CommentControllerIntegrationTest extends AbstractControllerIntegrat
     private DocumentNodeFactory documentNodeFactory;
     @Autowired
     private CurrentUserService currentUserService;
-    @Autowired
-    private ApplicationUserService applicationUserService;
 
     @Before
     public void before() {
@@ -122,9 +120,13 @@ public class CommentControllerIntegrationTest extends AbstractControllerIntegrat
     @Transactional
     public void findAll() throws Exception {
         final DocumentNode node = documentNodeFactory.save();
-        commentService.create(node.getId(), commentFactory.create());
-        commentService.create(node.getId(), commentFactory.create());
-        commentService.create(node.getId(), commentFactory.create());
+        final CommentDetailDto comment1 = commentService.create(node.getId(), commentFactory.create());
+        final CommentDetailDto comment2 = commentService.create(node.getId(), commentFactory.create());
+        final CommentDetailDto comment3 = commentService.create(node.getId(), commentFactory.create());
+
+        commentService.setStatus(comment1.getId(), APPROVED);
+        commentService.setStatus(comment2.getId(), APPROVED);
+        commentService.setStatus(comment3.getId(), APPROVED);
 
         mvc.perform(get(endpoint("/api/documentnodes/", node.getId(), "/comments?page=0"))
                 .accept(MediaType.APPLICATION_JSON))
@@ -151,7 +153,7 @@ public class CommentControllerIntegrationTest extends AbstractControllerIntegrat
     public void approve() throws Exception {
         final DocumentNode node = documentNodeFactory.save();
         CommentDetailDto comment = commentService.create(node.getId(), commentFactory.create());
-        mvc.perform(get(endpoint("/api/documentnodes/", node.getId(), "/comments/", comment.getId(), "/approve"))
+        mvc.perform(get(endpoint("/api/comments/", comment.getId(), "/approve"))
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value(APPROVED.toString()))
                 .andExpect(status().isOk());
@@ -163,7 +165,7 @@ public class CommentControllerIntegrationTest extends AbstractControllerIntegrat
     public void reject() throws Exception {
         final DocumentNode node = documentNodeFactory.save();
         CommentDetailDto comment = commentService.create(node.getId(), commentFactory.create());
-        mvc.perform(get(endpoint("/api/documentnodes/", node.getId(), "/comments/", comment.getId(), "/reject"))
+        mvc.perform(get(endpoint("/api/comments/", comment.getId(), "/reject"))
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.status").value(REJECTED.toString()))
                 .andExpect(status().isOk());

--- a/src/test/java/com/code4ro/legalconsultation/comment/factory/CommentFactory.java
+++ b/src/test/java/com/code4ro/legalconsultation/comment/factory/CommentFactory.java
@@ -3,6 +3,7 @@ package com.code4ro.legalconsultation.comment.factory;
 import com.code4ro.legalconsultation.comment.model.dto.CommentDetailDto;
 import com.code4ro.legalconsultation.comment.model.dto.CommentDto;
 import com.code4ro.legalconsultation.comment.model.persistence.Comment;
+import com.code4ro.legalconsultation.comment.model.persistence.CommentStatus;
 import com.code4ro.legalconsultation.comment.service.CommentService;
 import com.code4ro.legalconsultation.core.factory.RandomObjectFiller;
 import com.code4ro.legalconsultation.authentication.model.persistence.ApplicationUser;
@@ -23,7 +24,7 @@ public final class CommentFactory {
         final CommentDto commentDto = RandomObjectFiller.createAndFill(CommentDto.class);
         if (commentDto == null) throw new IllegalArgumentException("Failed to create the comment");
         commentDto.setLastEditDateTime(new Date());
-        commentDto.setStatus(null);
+        commentDto.setStatus(CommentStatus.PENDING);
         return commentDto;
     }
 

--- a/src/test/java/com/code4ro/legalconsultation/core/controller/AbstractControllerIntegrationTest.java
+++ b/src/test/java/com/code4ro/legalconsultation/core/controller/AbstractControllerIntegrationTest.java
@@ -37,11 +37,10 @@ public abstract class AbstractControllerIntegrationTest {
     protected ApplicationUserService applicationUserService;
     @MockBean
     protected JavaMailSender mailSender;
-
     @Autowired
-    private UserRepository userRepository;
+    protected UserRepository userRepository;
     @Autowired
-    private InvitationRepository invitationRepository;
+    protected InvitationRepository invitationRepository;
 
     protected static String endpoint(Object... args) {
         final List<String> stringArgs = Arrays.stream(args)

--- a/src/test/java/com/code4ro/legalconsultation/document/core/controller/DocumentControllerIntegrationTest.java
+++ b/src/test/java/com/code4ro/legalconsultation/document/core/controller/DocumentControllerIntegrationTest.java
@@ -3,6 +3,8 @@ package com.code4ro.legalconsultation.document.core.controller;
 import com.amazonaws.util.json.Jackson;
 import com.code4ro.legalconsultation.comment.factory.CommentFactory;
 import com.code4ro.legalconsultation.comment.model.dto.CommentDetailDto;
+import com.code4ro.legalconsultation.comment.model.persistence.CommentStatus;
+import com.code4ro.legalconsultation.comment.service.CommentService;
 import com.code4ro.legalconsultation.core.controller.AbstractControllerIntegrationTest;
 import com.code4ro.legalconsultation.core.factory.RandomObjectFiller;
 import com.code4ro.legalconsultation.document.configuration.model.persistence.DocumentConfiguration;
@@ -53,6 +55,8 @@ public class DocumentControllerIntegrationTest extends AbstractControllerIntegra
     private DocumentNodeFactory documentNodeFactory;
     @Autowired
     private CommentFactory commentFactory;
+    @Autowired
+    private CommentService commentService;
 
     @Test
     @WithMockUser
@@ -260,9 +264,15 @@ public class DocumentControllerIntegrationTest extends AbstractControllerIntegra
         CommentDetailDto comment1 = commentFactory.save(consolidated.getDocumentNode().getId());
         CommentDetailDto comment2 = commentFactory.save(consolidated.getDocumentNode().getId());
 
-        commentFactory.saveReply(comment1.getId());
-        commentFactory.saveReply(comment1.getId());
-        commentFactory.saveReply(comment2.getId());
+        final CommentDetailDto reply1 = commentFactory.saveReply(comment1.getId());
+        final CommentDetailDto reply2 = commentFactory.saveReply(comment1.getId());
+        final CommentDetailDto reply3 = commentFactory.saveReply(comment2.getId());
+
+        commentService.setStatus(comment1.getId(), CommentStatus.APPROVED);
+        commentService.setStatus(comment2.getId(), CommentStatus.APPROVED);
+        commentService.setStatus(reply1.getId(), CommentStatus.APPROVED);
+        commentService.setStatus(reply2.getId(), CommentStatus.APPROVED);
+        commentService.setStatus(reply3.getId(), CommentStatus.APPROVED);
 
         mvc.perform(get(endpoint("/api/documents/", consolidated.getDocumentMetadata().getId(), "/consolidated"))
                 .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/code4ro/legalconsultation/document/node/factory/DocumentFactory.java
+++ b/src/test/java/com/code4ro/legalconsultation/document/node/factory/DocumentFactory.java
@@ -1,0 +1,38 @@
+package com.code4ro.legalconsultation.document.node.factory;
+
+import com.code4ro.legalconsultation.core.factory.RandomObjectFiller;
+import com.code4ro.legalconsultation.document.configuration.model.persistence.DocumentConfiguration;
+import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
+import com.code4ro.legalconsultation.document.consolidated.repository.DocumentConsolidatedRepository;
+import com.code4ro.legalconsultation.document.metadata.model.persistence.DocumentMetadata;
+import com.code4ro.legalconsultation.document.metadata.repository.DocumentMetadataRepository;
+import com.code4ro.legalconsultation.document.node.model.persistence.DocumentNode;
+import com.code4ro.legalconsultation.user.model.persistence.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DocumentFactory {
+    @Autowired
+    private DocumentConsolidatedRepository documentConsolidatedRepository;
+    @Autowired
+    private DocumentNodeFactory documentNodeFactory;
+    @Autowired
+    private DocumentMetadataRepository documentMetadataRepository;
+
+    public DocumentConsolidated create() {
+        final DocumentNode rootNode = documentNodeFactory.create();
+        final DocumentMetadata metadata = documentMetadataRepository
+                .save(RandomObjectFiller.createAndFillWithBaseEntity(DocumentMetadata.class));
+
+        final DocumentConsolidated documentConsolidated = new DocumentConsolidated();
+        documentConsolidated.setDocumentNode(rootNode);
+        documentConsolidated.setDocumentConfiguration(new DocumentConfiguration());
+        documentConsolidated.setDocumentMetadata(metadata);
+
+        return documentConsolidatedRepository.save(documentConsolidated);
+    }
+
+}

--- a/src/test/java/com/code4ro/legalconsultation/user/factory/UserFactory.java
+++ b/src/test/java/com/code4ro/legalconsultation/user/factory/UserFactory.java
@@ -1,0 +1,21 @@
+package com.code4ro.legalconsultation.user.factory;
+
+import com.code4ro.legalconsultation.authentication.model.persistence.ApplicationUser;
+import com.code4ro.legalconsultation.core.factory.RandomObjectFiller;
+import com.code4ro.legalconsultation.user.model.persistence.User;
+import com.code4ro.legalconsultation.user.model.persistence.UserRole;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserFactory {
+
+    public ApplicationUser createApplicationUserWithRole(final UserRole role) {
+        final User user = RandomObjectFiller.createAndFillWithBaseEntity(User.class);
+        user.setRole(role);
+
+        final ApplicationUser applicationUser = RandomObjectFiller.createAndFillWithBaseEntity(ApplicationUser.class);
+        applicationUser.setUser(user);
+
+        return applicationUser;
+    }
+}


### PR DESCRIPTION
Get pending comments endpoint.

If the user is `owner` or `admin` it returns comments from all documents which need approval.
If the user is `regular` (contribuitor) it returns comments from all documents where the user is assigned to them.

All the results are paginated