### PR TITLE
move consultation data to document configuration

### DIFF
--- a/src/main/java/com/code4ro/legalconsultation/document/configuration/mapper/DocumentConfigurationMapper.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/configuration/mapper/DocumentConfigurationMapper.java
@@ -1,0 +1,12 @@
+package com.code4ro.legalconsultation.document.configuration.mapper;
+
+import com.code4ro.legalconsultation.document.configuration.model.dto.DocumentConfigurationDto;
+import com.code4ro.legalconsultation.document.configuration.model.persistence.DocumentConfiguration;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface DocumentConfigurationMapper {
+    DocumentConfigurationDto map(DocumentConfiguration documentConfiguration);
+
+    DocumentConfiguration map(DocumentConfigurationDto documentConfigurationDto);
+}

--- a/src/main/java/com/code4ro/legalconsultation/document/configuration/model/dto/DocumentConfigurationDto.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/configuration/model/dto/DocumentConfigurationDto.java
@@ -4,9 +4,14 @@ import com.code4ro.legalconsultation.core.model.dto.BaseEntityDto;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Date;
+
 @Getter
 @Setter
 public class DocumentConfigurationDto extends BaseEntityDto {
     private Boolean openForCommenting;
     private Boolean openForVotingComments;
+    private Date consultationStartDate;
+    private Date consultationDeadline;
+    private Boolean excludedFromConsultation;
 }

--- a/src/main/java/com/code4ro/legalconsultation/document/configuration/model/persistence/DocumentConfiguration.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/configuration/model/persistence/DocumentConfiguration.java
@@ -1,12 +1,21 @@
 package com.code4ro.legalconsultation.document.configuration.model.persistence;
 
 import com.code4ro.legalconsultation.core.model.persistence.BaseEntity;
+import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
 
 @Entity
 @Table(name = "document_configuration")
@@ -16,9 +25,29 @@ import javax.persistence.*;
 @AllArgsConstructor
 public class DocumentConfiguration extends BaseEntity {
 
+    public DocumentConfiguration(Boolean openForCommenting, Boolean openForVotingComments) {
+        this.openForCommenting = openForCommenting;
+        this.openForVotingComments = openForVotingComments;
+    }
+
     @Column(name = "is_open_for_commenting")
     private Boolean openForCommenting;
 
     @Column(name = "is_open_for_voting_comments")
     private Boolean openForVotingComments;
+
+    @Column(name = "consultation_start_date")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date consultationStartDate;
+
+    @Column(name = "consultation_deadline")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date consultationDeadline;
+
+    @Column(name = "is_excluded_from_consultation")
+    private Boolean excludedFromConsultation;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    private DocumentConsolidated documentConsolidated;
 }

--- a/src/main/java/com/code4ro/legalconsultation/document/configuration/service/DocumentConfigurationService.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/configuration/service/DocumentConfigurationService.java
@@ -1,0 +1,36 @@
+package com.code4ro.legalconsultation.document.configuration.service;
+
+import com.code4ro.legalconsultation.document.configuration.model.persistence.DocumentConfiguration;
+import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentConsultationDataDto;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+public interface DocumentConfigurationService {
+    @Transactional(readOnly = true)
+    DocumentConfiguration getEntity(UUID id);
+
+    /**
+     * Adds information about the consultation period of a document
+     *
+     * @param metadataId                  of the document to be updated
+     * @param consultationDataDto consultation start date, deadline and exclusion flag
+     */
+    void addConsultationData(UUID metadataId, DocumentConsultationDataDto consultationDataDto);
+
+    /**
+     * Loads consultation data for a given document id
+     *
+     * @param id of the document
+     * @return consultation data of the document
+     */
+    DocumentConsultationDataDto getConsultationData(UUID id);
+
+    /**
+     * Saves a document configuration
+     * @param documentConfiguration .
+     * @return saved document configuration
+     */
+    DocumentConfiguration saveOne(final DocumentConfiguration documentConfiguration);
+
+}

--- a/src/main/java/com/code4ro/legalconsultation/document/configuration/service/DocumentConfigurationServiceImpl.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/configuration/service/DocumentConfigurationServiceImpl.java
@@ -1,0 +1,59 @@
+package com.code4ro.legalconsultation.document.configuration.service;
+
+import com.code4ro.legalconsultation.document.configuration.model.persistence.DocumentConfiguration;
+import com.code4ro.legalconsultation.document.configuration.repository.DocumentConfigurationRepository;
+import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentConsultationDataDto;
+import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
+import com.code4ro.legalconsultation.document.consolidated.service.DocumentConsolidatedService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.UUID;
+
+@Service
+public class DocumentConfigurationServiceImpl implements DocumentConfigurationService {
+
+    private final DocumentConfigurationRepository documentConfigurationRepository;
+    private final DocumentConsolidatedService documentConsolidatedService;
+
+    @Autowired
+    public DocumentConfigurationServiceImpl(final DocumentConfigurationRepository repository,
+                                            final DocumentConsolidatedService documentConsolidatedService) {
+        this.documentConfigurationRepository = repository;
+        this.documentConsolidatedService = documentConsolidatedService;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DocumentConfiguration getEntity(final UUID id) {
+        return documentConfigurationRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+    }
+
+    @Transactional
+    public DocumentConfiguration saveOne(final DocumentConfiguration documentConfiguration) {
+        return documentConfigurationRepository.save(documentConfiguration);
+    }
+
+    @Transactional
+    @Override
+    public void addConsultationData(final UUID metadataId, final DocumentConsultationDataDto consultationDataDto) {
+        final DocumentConsolidated documentConsolidated =
+                this.documentConsolidatedService.getByDocumentMetadataId(metadataId);
+        final DocumentConfiguration documentConfiguration = documentConsolidated.getDocumentConfiguration();
+        documentConfiguration.setConsultationStartDate(consultationDataDto.getConsultationStartDate());
+        documentConfiguration.setConsultationDeadline(consultationDataDto.getConsultationDeadline());
+        documentConfiguration.setExcludedFromConsultation(consultationDataDto.getExcludedFromConsultation());
+        this.saveOne(documentConfiguration);
+    }
+
+    @Override
+    public DocumentConsultationDataDto getConsultationData(final UUID metadataId) {
+        final DocumentConsolidated documentConsolidated =
+                this.documentConsolidatedService.getByDocumentMetadataId(metadataId);
+        final DocumentConfiguration documentConfiguration = documentConsolidated.getDocumentConfiguration();
+        return new DocumentConsultationDataDto(documentConfiguration.getConsultationStartDate(),
+                documentConfiguration.getConsultationDeadline(), documentConfiguration.getExcludedFromConsultation());
+    }
+}

--- a/src/main/java/com/code4ro/legalconsultation/document/consolidated/model/dto/DocumentConsolidatedDto.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/consolidated/model/dto/DocumentConsolidatedDto.java
@@ -18,7 +18,4 @@ public class DocumentConsolidatedDto extends BaseEntityDto {
     private DocumentNodeDto documentNode;
     private DocumentConfigurationDto documentConfiguration;
     private List<UserDto> assignedUsers;
-    private Date startDate;
-    private Date consultationDeadline;
-    private Boolean excludedFromConsultation;
 }

--- a/src/main/java/com/code4ro/legalconsultation/document/consolidated/model/dto/DocumentConsultationDataDto.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/consolidated/model/dto/DocumentConsultationDataDto.java
@@ -10,7 +10,7 @@ import java.util.Date;
 @Setter
 @AllArgsConstructor
 public class DocumentConsultationDataDto {
-    private Date startDate;
+    private Date consultationStartDate;
     private Date consultationDeadline;
     private Boolean excludedFromConsultation;
 }

--- a/src/main/java/com/code4ro/legalconsultation/document/consolidated/model/persistence/DocumentConsolidated.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/consolidated/model/persistence/DocumentConsolidated.java
@@ -8,9 +8,15 @@ import com.code4ro.legalconsultation.user.model.persistence.User;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
 import java.util.List;
-import java.util.Date;
 
 @Entity
 @Table(name = "consolidated_document")
@@ -26,8 +32,10 @@ public class DocumentConsolidated extends BaseEntity {
     @JoinColumn(name = "document_node_id")
     private DocumentNode documentNode;
 
-    @OneToOne(fetch = FetchType.EAGER, optional = false, cascade = CascadeType.ALL)
-    @JoinColumn(name = "configuration_id")
+    @OneToOne(fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            mappedBy = "documentConsolidated")
     private DocumentConfiguration documentConfiguration;
 
     @ManyToMany(fetch = FetchType.LAZY)
@@ -36,17 +44,6 @@ public class DocumentConsolidated extends BaseEntity {
             joinColumns = @JoinColumn(name = "document_id"),
             inverseJoinColumns = @JoinColumn(name = "user_id"))
     private List<User> assignedUsers;
-
-    @Column(name = "start_date")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date startDate;
-
-    @Column(name = "consultation_deadline")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date consultationDeadline;
-
-    @Column(name = "is_excluded_from_consultation")
-    private Boolean excludedFromConsultation;
 
     public DocumentConsolidated(final DocumentMetadata documentMetadata,
                                 final DocumentNode documentNode,

--- a/src/main/java/com/code4ro/legalconsultation/document/core/controller/DocumentController.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/core/controller/DocumentController.java
@@ -1,6 +1,7 @@
 package com.code4ro.legalconsultation.document.core.controller;
 
 import com.code4ro.legalconsultation.core.model.dto.PageDto;
+import com.code4ro.legalconsultation.document.configuration.service.DocumentConfigurationService;
 import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentConsolidatedDto;
 import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentConsultationDataDto;
 import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentUserAssignmentDto;
@@ -21,7 +22,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
@@ -34,6 +43,7 @@ import java.util.UUID;
 public class DocumentController {
 
     private final DocumentService documentService;
+    private final DocumentConfigurationService documentConfigurationService;
 
     @ApiOperation(value = "Return document metadata for all documents in the platform",
             response = PageDto.class,
@@ -140,19 +150,20 @@ public class DocumentController {
     }
 
     @ApiOperation("Add consultation data to a document")
-    @PostMapping("/{id}/consultation")
+    @PostMapping("/{metadataId}/consultation")
     public ResponseEntity<Void> addConsultationData(
-            @ApiParam(value = "Id of the document being modified") @PathVariable("id") UUID id,
+            @ApiParam(value = "Id of the document metadata of the document being modified") @PathVariable("metadataId")
+                    UUID metadataId,
             @Valid @RequestBody DocumentConsultationDataDto documentConsultationDataDto) {
-        documentService.addConsultationData(id, documentConsultationDataDto);
+        documentConfigurationService.addConsultationData(metadataId, documentConsultationDataDto);
         return ResponseEntity.ok().build();
     }
 
     @ApiOperation("Get consultation data of a document")
-    @GetMapping("{id}/consultation")
+    @GetMapping("{metadataId}/consultation")
     public ResponseEntity<DocumentConsultationDataDto> getConsultationData(
-            @ApiParam(value = "Id of the document") @PathVariable("id") UUID id) {
-        final DocumentConsultationDataDto consultationData = documentService.getConsultationData(id);
+            @ApiParam(value = "Id of the metadata of the document") @PathVariable("metadataId") UUID id) {
+        final DocumentConsultationDataDto consultationData = documentConfigurationService.getConsultationData(id);
         return ResponseEntity.ok(consultationData);
     }
 }

--- a/src/main/java/com/code4ro/legalconsultation/document/core/service/DocumentService.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/core/service/DocumentService.java
@@ -1,7 +1,6 @@
 package com.code4ro.legalconsultation.document.core.service;
 
 import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentConsolidatedDto;
-import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentConsultationDataDto;
 import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
 import com.code4ro.legalconsultation.document.export.model.DocumentExportFormat;
 import com.code4ro.legalconsultation.document.metadata.model.dto.DocumentMetadataDto;
@@ -57,9 +56,4 @@ public interface DocumentService {
     byte[] export(final UUID id, final DocumentExportFormat type);
 
     List<UUID> getAllAssignedDocumentsNodeIds(User user);
-
-    void addConsultationData(final UUID id, final DocumentConsultationDataDto consultationDataDto);
-
-    DocumentConsultationDataDto getConsultationData(final UUID id);
-
 }

--- a/src/main/java/com/code4ro/legalconsultation/document/core/service/impl/DocumentServiceImpl.java
+++ b/src/main/java/com/code4ro/legalconsultation/document/core/service/impl/DocumentServiceImpl.java
@@ -1,10 +1,9 @@
 package com.code4ro.legalconsultation.document.core.service.impl;
 
 import com.code4ro.legalconsultation.document.configuration.model.persistence.DocumentConfiguration;
+import com.code4ro.legalconsultation.document.configuration.service.DocumentConfigurationService;
 import com.code4ro.legalconsultation.document.consolidated.mapper.DocumentConsolidatedMapper;
 import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentConsolidatedDto;
-import com.code4ro.legalconsultation.document.consolidated.model.dto.DocumentConsultationDataDto;
-import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
 import com.code4ro.legalconsultation.document.consolidated.model.persistence.DocumentConsolidated;
 import com.code4ro.legalconsultation.document.consolidated.service.DocumentConsolidatedService;
 import com.code4ro.legalconsultation.document.core.service.DocumentService;
@@ -26,8 +25,6 @@ import com.code4ro.legalconsultation.user.mapper.UserMapper;
 import com.code4ro.legalconsultation.user.model.dto.UserDto;
 import com.code4ro.legalconsultation.user.model.persistence.User;
 import com.code4ro.legalconsultation.user.service.UserService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,13 +32,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 public class DocumentServiceImpl implements DocumentService {
@@ -57,6 +51,8 @@ public class DocumentServiceImpl implements DocumentService {
     private final DocumentConsolidatedMapper documentConsolidatedMapper;
     private final PdfHandleMapper pdfHandleMapper;
     private final DocumentExporterFactory documentExporterFactory;
+    private final DocumentConfigurationService documentConfigurationService;
+
 
     @Autowired
     public DocumentServiceImpl(final DocumentConsolidatedService documentConsolidatedService,
@@ -69,7 +65,8 @@ public class DocumentServiceImpl implements DocumentService {
                                final DocumentConsolidatedMapper documentConsolidatedMapper,
                                final PdfHandleMapper pdfHandleMapper,
                                final DocumentExporterFactory documentExporterFactory,
-                               final MailApi mailService) {
+                               final MailApi mailService,
+                               final DocumentConfigurationService documentConfigurationService) {
         this.documentConsolidatedService = documentConsolidatedService;
         this.documentMetadataService = documentMetadataService;
         this.pdfService = pdfService;
@@ -81,6 +78,7 @@ public class DocumentServiceImpl implements DocumentService {
         this.pdfHandleMapper = pdfHandleMapper;
         this.documentExporterFactory = documentExporterFactory;
         this.mailService = mailService;
+        this.documentConfigurationService = documentConfigurationService;
     }
 
     @Transactional(readOnly = true)
@@ -120,9 +118,15 @@ public class DocumentServiceImpl implements DocumentService {
         metadata.setFilePath(document.getFilePath());
         final String pdfContent = pdfService.readAsString(storageApi.loadFile(document.getFilePath()));
         final DocumentNode documentNode = documentNodeService.parse(pdfContent);
-        final DocumentConfiguration documentConfiguration = new DocumentConfiguration(true, true);
+        final DocumentConsolidated documentConsolidated = new DocumentConsolidated(metadata, documentNode);
+        final DocumentConsolidated savedDocumentConsolidated =
+                documentConsolidatedService.saveOne(documentConsolidated);
 
-        return documentConsolidatedService.saveOne(new DocumentConsolidated(metadata, documentNode, documentConfiguration));
+        final DocumentConfiguration documentConfiguration = new DocumentConfiguration(true, true);
+        documentConfiguration.setDocumentConsolidated(documentConsolidated);
+        documentConfigurationService.saveOne(documentConfiguration);
+
+        return savedDocumentConsolidated;
     }
 
     @Transactional
@@ -194,22 +198,5 @@ public class DocumentServiceImpl implements DocumentService {
                 .flatMap(document -> document.getDocumentNode().flattened())
                 .map(DocumentNode::getId)
                 .collect(Collectors.toList());
-    }
-
-
-    @Override
-    public void addConsultationData(final UUID id, final DocumentConsultationDataDto consultationDataDto) {
-        final DocumentConsolidated documentConsolidated = documentConsolidatedService.getByDocumentMetadataId(id);
-        documentConsolidated.setStartDate(consultationDataDto.getStartDate());
-        documentConsolidated.setConsultationDeadline(consultationDataDto.getConsultationDeadline());
-        documentConsolidated.setExcludedFromConsultation(consultationDataDto.getExcludedFromConsultation());
-        documentConsolidatedService.saveOne(documentConsolidated);
-    }
-
-    @Override
-    public DocumentConsultationDataDto getConsultationData(final UUID id) {
-        final DocumentConsolidated documentConsolidated = documentConsolidatedService.getByDocumentMetadataId(id);
-        return new DocumentConsultationDataDto(documentConsolidated.getStartDate(),
-                documentConsolidated.getConsultationDeadline(), documentConsolidated.getExcludedFromConsultation());
     }
 }


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

This moves the consultation fields from the DocumentConsolidated class to the DocumentConfiguration class.

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

DocumentControllerIntegration test

<!-- If applicable, mention any known issues with the pull request -->
